### PR TITLE
evaluateJavaScript() signature changed.

### DIFF
--- a/src/ios/app/AppDelegate+threedeetouch.m
+++ b/src/ios/app/AppDelegate+threedeetouch.m
@@ -22,7 +22,7 @@
       [threeDeeTouch.webView performSelectorOnMainThread:@selector(stringByEvaluatingJavaScriptFromString:) withObject:function waitUntilDone:NO];
     } else {
       // Cordova-iOS 4+
-      [threeDeeTouch.webView performSelectorOnMainThread:@selector(evaluateJavaScript:completionHandler:) withObject:function waitUntilDone:NO];
+      [threeDeeTouch.webView performSelector:@selector(evaluateJavaScript:completionHandler:) withObject:function withObject:nil];
     }
   } else {
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 25 * NSEC_PER_MSEC), dispatch_get_main_queue(), ^{


### PR DESCRIPTION
Hi! I'm using Cordova 4+ and noticed that the evaluateJavaScript() method signature changed. I was getting a crash because the selector method wasn't found.