### PR TITLE
Remove unused import

### DIFF
--- a/src/ios/app/AppDelegate+threedeetouch.m
+++ b/src/ios/app/AppDelegate+threedeetouch.m
@@ -1,7 +1,6 @@
 #import "AppDelegate+threedeetouch.h"
 #import "ThreeDeeTouch.h"
 #import <objc/runtime.h>
-#import "MainViewController.h"
 
 @implementation AppDelegate (threedeetouch)
 


### PR DESCRIPTION
The MainViewController.h import is not used and prevents the app from building in Capacitor (https://github.com/ionic-team/capacitor/issues/1307)


