### PR TITLE
Ionic 4 compatibility

### DIFF
--- a/www/ThreeDeeTouch.js
+++ b/www/ThreeDeeTouch.js
@@ -23,11 +23,13 @@ ThreeDeeTouch.prototype.configureQuickActions = function (icons, onSuccess, onEr
   exec(onSuccess, onError, "ThreeDeeTouch", "configureQuickActions", [icons]);
 };
 
+ThreeDeeTouch.prototype.onHomeIconPressed = function(){};
+
 module.exports = new ThreeDeeTouch();
 
 var remainingAttempts = 150;
 function waitForIt() {
-  if (window.ThreeDeeTouch && typeof window.ThreeDeeTouch.onHomeIconPressed === "function") {
+  if (window.ThreeDeeTouch && typeof window.ThreeDeeTouch.onHomeIconPressed !== ThreeDeeTouch.prototype.onHomeIconPressed) {
     exec(null, null, "ThreeDeeTouch", "deviceIsReady", []);
   } else if (remainingAttempts-- > 0) {
     setTimeout(waitForIt, 100);


### PR DESCRIPTION
Hi!

In ionic 4 have an issue what is based on this 2 file :

https://github.com/ionic-team/ionic-native/blob/master/src/%40ionic-native/plugins/three-dee-touch/index.ts#L168
https://github.com/ionic-team/ionic-native/blob/master/src/%40ionic-native/core/decorators/cordova-function-override.ts#L7
File 1. says, the method should exist to overwrite it.
File 2. implements file 1.

The solution is very easy and you have to modify only one file.

**www/ThreeDeeTouch.js **
You have to define the onHomeIconPressed function :
ThreeDeeTouch.prototype.onHomeIconPressed = function(){};
Then in the waitForIt function you have to modify the if :
if (window.ThreeDeeTouch && typeof window.ThreeDeeTouch.onHomeIconPressed !==ThreeDeeTouch.prototype.onHomeIconPressed)

In your case the function does not exist.
In my case the function exist but if the function was modified by a developer its trigger the deviceReady on native-site.