### PR TITLE
Support WKWebViewOnly build settings

### DIFF
--- a/src/ios/app/ThreeDeeTouch.m
+++ b/src/ios/app/ThreeDeeTouch.m
@@ -33,18 +33,22 @@
 }
 
 - (void) enableLinkPreview:(CDVInvokedUrlCommand *)command {
+#if !WK_WEB_VIEW_ONLY
     if ([self.webView class] == [UIWebView class]) {
         UIWebView *w = (UIWebView*)self.webView;
         w.allowsLinkPreview = YES;
     }
+#endif
     [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK] callbackId:command.callbackId];
 }
 
 - (void) disableLinkPreview:(CDVInvokedUrlCommand *)command {
+#if !WK_WEB_VIEW_ONLY
     if ([self.webView class] == [UIWebView class]) {
         UIWebView *w = (UIWebView*)self.webView;
         w.allowsLinkPreview = NO;
     }
+#endif
     [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK] callbackId:command.callbackId];
 }
 


### PR DESCRIPTION
Apple issues a warning if the submitted app contains references to the deprecated UIWebView API.
So this PR supports the WKWebViewOnly preferences and removes any references at build time.

For more details see: [apache/cordova-ios#661](https://github.com/apache/cordova-ios/issues/661)