### PR TITLE
Update to callback mechanism for shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,13 +124,15 @@ the icon was used to launch your app. So make sure it's unique amongst your icon
   ]);
 ```
 
-### onHomeIconPressed
-When a home icon is pressed, your app launches and this JS callback is invoked. I found it worked
-reliable when you use it like this (you should recognize the `type` params used previously):
+### registerCallback
+
+When your app launches, make sure to call this method to register a callback that will be invoked when a HomeScreen shortcut is activated by the user. If the app was launched by a shortcut, the callback will be called immediately.
+
+> Once the callback is registered, it may be called multiple times. For example, if the user sends the app to the background and re-activates it via a shortcut.
 
 ```js
   document.addEventListener('deviceready', function () {
-    ThreeDeeTouch.onHomeIconPressed = function (payload) {
+    ThreeDeeTouch.registerCallback(function (payload) {
       console.log("Icon pressed. Type: " + payload.type + ". Title: " + payload.title + ".");
       if (payload.type == 'checkin') {
         document.location = 'checkin.html';
@@ -140,7 +142,10 @@ reliable when you use it like this (you should recognize the `type` params used 
         // hook up any other icons you may have and do something awesome (e.g. launch the Camera UI, then share the image to Twitter)
         console.log(JSON.stringify(payload));
       }
-    }
+    },
+    error => {
+      console.log("Failed to register shortcut callback", error);
+    });
   }, false);
 ```
 
@@ -216,6 +221,7 @@ This is the same as the `type` param of `configureQuickActions`, so it's what yo
 `onHomeIconPressed` as `payload.type`. Just do something cool with that info.
 
 ## 6. Changelog
+* T.B.D Avoid race conditions when registering for shortcut callbacks during app startup
 * 1.3.8 Support WKWebViewOnly build settings, thanks [#45](https://github.com/EddyVerbruggen/cordova-plugin-3dtouch/pull/45)!
 * 1.3.7 Ionic 4 compat, thanks [#43](https://github.com/EddyVerbruggen/cordova-plugin-3dtouch/issues/43)!
 * 1.3.6 Get back the subtitle when a home icon was pressed, thanks [#27](https://github.com/EddyVerbruggen/cordova-plugin-3dtouch/issues/27)!

--- a/src/ios/app/AppDelegate+threedeetouch.m
+++ b/src/ios/app/AppDelegate+threedeetouch.m
@@ -5,34 +5,15 @@
 @implementation AppDelegate (threedeetouch)
 
 - (void)application:(UIApplication *)application performActionForShortcutItem:(UIApplicationShortcutItem *)shortcutItem completionHandler:(void(^)(BOOL succeeded))completionHandler {
-
-  NSString* jsFunction = @"ThreeDeeTouch.onHomeIconPressed";
-  NSString *params = [NSString stringWithFormat:@"{'type':'%@', 'title': '%@', 'subtitle': '%@'}", shortcutItem.type, shortcutItem.localizedTitle, shortcutItem.localizedSubtitle];
-  NSString* result = [NSString stringWithFormat:@"%@(%@)", jsFunction, params];
-  [self callJavascriptFunctionWhenAvailable:result];
-}
-
-// check every x seconds for the phone  app to be ready, or stop from glance.didDeactivate
-- (void) callJavascriptFunctionWhenAvailable:(NSString*)function {
-  ThreeDeeTouch *threeDeeTouch = [self.viewController getCommandInstance:@"ThreeDeeTouch"];
-  if (threeDeeTouch.initDone) {
-    if ([threeDeeTouch.webView respondsToSelector:@selector(stringByEvaluatingJavaScriptFromString:)]) {
-      // UIWebView
-      [threeDeeTouch.webView performSelectorOnMainThread:@selector(stringByEvaluatingJavaScriptFromString:) withObject:function waitUntilDone:NO];
-    } else if ([threeDeeTouch.webView respondsToSelector:@selector(evaluateJavaScript:completionHandler:)]) {
-      // WKWebView
-      [threeDeeTouch.webView performSelector:@selector(evaluateJavaScript:completionHandler:) withObject:function withObject:nil];
-    } else {
-      NSLog(@"No compatible method found to communicate 3D Touch callback to the webview. Please notify the plugin author.");
-    }
-  } else {
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 25 * NSEC_PER_MSEC), dispatch_get_main_queue(), ^{
-      [self callJavascriptFunctionWhenAvailable:function];
-    });
-  }
-}
-
-- (void)applicationDidBecomeActive:(UIApplication *)application {
+    
+    NSDictionary* message = @{
+        @"type": shortcutItem.type,
+        @"title": shortcutItem.localizedTitle,
+        @"subtitle": shortcutItem.localizedSubtitle
+    };
+    ThreeDeeTouch *threeDeeTouch = [self.viewController getCommandInstance:@"ThreeDeeTouch"];
+    [threeDeeTouch shortcutReceived:message];
+    completionHandler(YES);
 }
 
 @end

--- a/src/ios/app/AppDelegate+threedeetouch.m
+++ b/src/ios/app/AppDelegate+threedeetouch.m
@@ -12,7 +12,14 @@
         @"subtitle": shortcutItem.localizedSubtitle ?: @""
     };
     ThreeDeeTouch *threeDeeTouch = [self.viewController getCommandInstance:@"ThreeDeeTouch"];
-    [threeDeeTouch shortcutReceived:message];
+    if (threeDeeTouch != nil) {
+        // Plugin already instantiated (app was running) — deliver via callback directly.
+        [threeDeeTouch shortcutReceived:message];
+    } else {
+        // Plugin not yet instantiated (cold launch, JS not ready) — store in the
+        // file-scope static so getLaunchShortcut: can retrieve it once JS calls it.
+        [ThreeDeeTouch storeLaunchShortcut:message];
+    }
     completionHandler(YES);
 }
 

--- a/src/ios/app/AppDelegate+threedeetouch.m
+++ b/src/ios/app/AppDelegate+threedeetouch.m
@@ -9,7 +9,7 @@
     NSDictionary* message = @{
         @"type": shortcutItem.type,
         @"title": shortcutItem.localizedTitle,
-        @"subtitle": shortcutItem.localizedSubtitle
+        @"subtitle": shortcutItem.localizedSubtitle ?: @""
     };
     ThreeDeeTouch *threeDeeTouch = [self.viewController getCommandInstance:@"ThreeDeeTouch"];
     [threeDeeTouch shortcutReceived:message];

--- a/src/ios/app/ThreeDeeTouch.h
+++ b/src/ios/app/ThreeDeeTouch.h
@@ -2,18 +2,13 @@
 
 @interface ThreeDeeTouch : CDVPlugin
 
-@property BOOL initDone;
-
-- (void) deviceIsReady:(CDVInvokedUrlCommand*)command;
-
 - (void) isAvailable:(CDVInvokedUrlCommand*)command;
-
 - (void) watchForceTouches:(CDVInvokedUrlCommand*)command;
-
 - (void) configureQuickActions:(CDVInvokedUrlCommand*)command;
-
 - (void) enableLinkPreview:(CDVInvokedUrlCommand*)command;
 - (void) disableLinkPreview:(CDVInvokedUrlCommand*)command;
+- (void) registerCallback:(CDVInvokedUrlCommand*)command;
+- (void) shortcutReceived:(NSDictionary*)shortcut;
 
 @end
 

--- a/src/ios/app/ThreeDeeTouch.h
+++ b/src/ios/app/ThreeDeeTouch.h
@@ -8,7 +8,9 @@
 - (void) enableLinkPreview:(CDVInvokedUrlCommand*)command;
 - (void) disableLinkPreview:(CDVInvokedUrlCommand*)command;
 - (void) registerCallback:(CDVInvokedUrlCommand*)command;
+- (void) getLaunchShortcut:(CDVInvokedUrlCommand*)command;
 - (void) shortcutReceived:(NSDictionary*)shortcut;
++ (void) storeLaunchShortcut:(NSDictionary*)shortcut;
 
 @end
 

--- a/src/ios/app/ThreeDeeTouch.m
+++ b/src/ios/app/ThreeDeeTouch.m
@@ -5,9 +5,8 @@
 
 @implementation ThreeDeeTouch
 
-- (void) deviceIsReady:(CDVInvokedUrlCommand *)command {
-    self.initDone = YES;
-}
+NSDictionary* pendingShortcut = nil;
+NSString* shortcutCallbackId = nil;
 
 - (void) isAvailable:(CDVInvokedUrlCommand *)command {
     
@@ -117,6 +116,27 @@
     else {
         NSLog(@"Invalid iconType passed to the 3D Touch plugin. So not adding one.");
         return 0;
+    }
+}
+
+- (void) registerCallback:(CDVInvokedUrlCommand*)command {
+    shortcutCallbackId = command.callbackId;
+    if (pendingShortcut != nil) {
+        CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:pendingShortcut];
+        result.keepCallback = @TRUE;
+        [self.commandDelegate sendPluginResult:result callbackId:shortcutCallbackId];
+        pendingShortcut = nil;
+    }
+}
+
+- (void) shortcutReceived:(NSDictionary*)shortcut {
+    if (shortcutCallbackId != nil) {
+        CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:shortcut];
+        result.keepCallback = @TRUE;
+        [self.commandDelegate sendPluginResult:result callbackId:shortcutCallbackId];
+    }
+    else {
+        pendingShortcut = shortcut;
     }
 }
 @end

--- a/src/ios/app/ThreeDeeTouch.m
+++ b/src/ios/app/ThreeDeeTouch.m
@@ -121,11 +121,24 @@ NSString* shortcutCallbackId = nil;
 
 - (void) registerCallback:(CDVInvokedUrlCommand*)command {
     shortcutCallbackId = command.callbackId;
+    // pendingShortcut is intentionally NOT delivered here.
+    // It is retrieved explicitly via getLaunchShortcut, called from
+    // ShortcutsService.checkForShortcut() during the cold-launch flow.
+    // Delivering it here via sendPluginResult would race against
+    // checkForShortcut() and could result in double-delivery.
+}
+
++ (void) storeLaunchShortcut:(NSDictionary*)shortcut {
+    pendingShortcut = shortcut;
+}
+
+- (void) getLaunchShortcut:(CDVInvokedUrlCommand*)command {
     if (pendingShortcut != nil) {
         CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:pendingShortcut];
-        result.keepCallback = @TRUE;
-        [self.commandDelegate sendPluginResult:result callbackId:shortcutCallbackId];
         pendingShortcut = nil;
+        [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
+    } else {
+        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK] callbackId:command.callbackId];
     }
 }
 

--- a/www/ThreeDeeTouch.js
+++ b/www/ThreeDeeTouch.js
@@ -23,19 +23,8 @@ ThreeDeeTouch.prototype.configureQuickActions = function (icons, onSuccess, onEr
   exec(onSuccess, onError, "ThreeDeeTouch", "configureQuickActions", [icons]);
 };
 
-ThreeDeeTouch.prototype.onHomeIconPressed = function(){};
+ThreeDeeTouch.prototype.registerCallback = function(cb, onError) {
+  exec(cb, onError, "ThreeDeeTouch", "registerCallback");
+};
 
 module.exports = new ThreeDeeTouch();
-
-var remainingAttempts = 150;
-function waitForIt() {
-  if (window.ThreeDeeTouch && typeof window.ThreeDeeTouch.onHomeIconPressed !== ThreeDeeTouch.prototype.onHomeIconPressed) {
-    exec(null, null, "ThreeDeeTouch", "deviceIsReady", []);
-  } else if (remainingAttempts-- > 0) {
-    setTimeout(waitForIt, 100);
-  }
-}
-
-// Call the plugin as soon as deviceready fires, this makes sure the webview is loaded, way more solid than relying on native's pluginInitialize.
-// Still, if the first attempt fails we will re-check for a little while because a fwk like Meteor will only make the function available after a little while.
-document.addEventListener('deviceready', waitForIt, false);

--- a/www/ThreeDeeTouch.js
+++ b/www/ThreeDeeTouch.js
@@ -27,4 +27,8 @@ ThreeDeeTouch.prototype.registerCallback = function(cb, onError) {
   exec(cb, onError, "ThreeDeeTouch", "registerCallback");
 };
 
+ThreeDeeTouch.prototype.getLaunchShortcut = function(onSuccess, onError) {
+  exec(onSuccess, onError, "ThreeDeeTouch", "getLaunchShortcut", []);
+};
+
 module.exports = new ThreeDeeTouch();


### PR DESCRIPTION
The current approach that the plugin uses to register the callback for Home Icon shortcuts is vulnerable to race conditions and in some cases the callback is not raised when the app is launched via a shortcut, even though it works reliable when the shortcut is activated while the app is in the background.

The approach introduced by this change does not rely on synchronization between the plug-in and the app initialization. The plug-in will remember the shortcut that launched the app and raise the callback as soon as the app provides one.

On automated testing, before this change, the callback would work for ~90% of app-launch shortcuts. After this change, the callback is raised for 100% of app-launch shortcuts.

THIS IS A BREAKING CHANGE - see README for details